### PR TITLE
Refactor Cloudinary config: use environment variables instead of hardcoded credentials

### DIFF
--- a/src/middlewares/upload.js
+++ b/src/middlewares/upload.js
@@ -1,11 +1,14 @@
 import multer from 'multer';
 import { v2 as cloudinary } from 'cloudinary';
 import { CloudinaryStorage } from 'multer-storage-cloudinary';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 cloudinary.config({
-  cloud_name: 'karinashcherbakova',
-  api_key: '967245142759389',
-  api_secret: 'EMUsgjKgYTl5V98rq0zSH00IVI8',
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
 });
 
 const storage = new CloudinaryStorage({


### PR DESCRIPTION
Refactor Cloudinary config: use environment variables instead of hardcoded credentials